### PR TITLE
fix KrakenRecognizerCommand check

### DIFF
--- a/manifests.json
+++ b/manifests.json
@@ -1,0 +1,1 @@
+{"https://gallica.bnf.fr/iiif/ark:/12148/bpt6k6328208z/manifest.json" : "LIV0007"}

--- a/rtk/task.py
+++ b/rtk/task.py
@@ -599,6 +599,40 @@ class KrakenRecognizerCommand(KrakenLikeCommand):
             **kwargs
         )
 
+    def check(self) -> bool:
+        all_done: bool = True
+        for inp in tqdm.tqdm(
+                self.input_files,
+                desc=_sbmsg("Checking prior processed documents"),
+                total=len(self.input_files)
+        ):
+            out = inp
+
+            if os.path.exists(out):
+                self._checked_files[inp] = self.check_alto_content(out)
+            else:
+                self._checked_files[inp] = False
+
+            all_done = all_done and self._checked_files[inp]
+
+        return all_done
+
+    def check_alto_content(self, file_path: str) -> bool:
+        try:
+            tree = ET.parse(file_path)
+            root = tree.getroot()
+
+            ns = {'alto': 'http://www.loc.gov/standards/alto/ns-v4#'}
+
+            for string in root.findall('.//alto:String', ns):
+                if string.get('CONTENT'):
+                    return True
+
+            return False
+        except ET.ParseError:
+            print(f"Error parsing XML file: {file_path}")
+            return False
+
     @staticmethod
     def pbar_parsing(stdout: str) -> str:
         return re.findall(r"Writing recognition results for ([^\t]+\.xml)", stdout)

--- a/rtk/utils.py
+++ b/rtk/utils.py
@@ -2,6 +2,7 @@
 from typing import Tuple, List, Optional, Dict, Union, Any, Callable
 import os
 import hashlib
+import json
 import csv
 from pathlib import Path
 # Non std lib
@@ -193,6 +194,22 @@ def batchify_textfile(filepath: str, batch_size: int = 100):
     with open(filepath) as f:
         text = f.read().split()
     return [text[n:n+batch_size] for n in range(0, len(text), batch_size)]
+
+
+def batchify_jsonfile(filepath: str, batch_size: int = 100):
+    """ Reads a JSON file containing manifest URLs and internal identifiers, and batch them
+
+    :param filepath: Path to the JSON file
+    :param batch_size: Size of each batch
+    :return: Tuple containing the manifest identifiers dictionary and the list of batches
+    """
+    with open(filepath, 'r') as file:
+        manifest_identifiers = json.load(file)
+
+    manifest_urls = list(manifest_identifiers.keys())
+    batches = [manifest_urls[n:n + batch_size] for n in range(0, len(manifest_urls), batch_size)]
+
+    return manifest_identifiers, batches
 
 
 def change_ext(filepath: str, new_ext: str) -> str:

--- a/rtk/utils.py
+++ b/rtk/utils.py
@@ -401,5 +401,9 @@ def cleverer_manifest_parsing(image: Dict[str, Any], head_check: bool = False) -
     return None
 
 
-def clean_kebab(string: str) -> str:
-    return cases.to_kebab(unidecode.unidecode(string))
+def clean_kebab(string: str, max_length: int = 255) -> str:
+    kebab_string = cases.to_kebab(unidecode.unidecode(string))
+    # trunc
+    if len(kebab_string) > max_length:
+        kebab_string = kebab_string[:max_length].rsplit('-', 1)[0]  # trunc last dash
+    return kebab_string

--- a/rtk/utils.py
+++ b/rtk/utils.py
@@ -401,7 +401,7 @@ def cleverer_manifest_parsing(image: Dict[str, Any], head_check: bool = False) -
     return None
 
 
-def clean_kebab(string: str, max_length: int = 255) -> str:
+def clean_kebab(string: str, max_length: int = 100) -> str:
     kebab_string = cases.to_kebab(unidecode.unidecode(string))
     # trunc
     if len(kebab_string) > max_length:

--- a/rtk/utils.py
+++ b/rtk/utils.py
@@ -12,6 +12,9 @@ import lxml.etree as ET
 import cases
 import unidecode
 from xml.sax.saxutils import escape
+import time
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 
 
@@ -35,10 +38,8 @@ def split_batches(inputs: List[str], splits: int) -> List[List[str]]:
     return result
 
 
-
 def download(url: str, target: str, options: Optional[Dict[str, str]] = None) -> Optional[str]:
     """ Download the element at [URL] and saves it at [TARGET] using binary writing. [OPTIONS] are fed to the headers
-
     :param url: A url
     :param target: A destination path
     :param options: A key-value dict for the request headers
@@ -46,15 +47,29 @@ def download(url: str, target: str, options: Optional[Dict[str, str]] = None) ->
     """
     headers = {}
     headers.update(options or {})
+
     os.makedirs(os.path.dirname(target), exist_ok=True)
+
+    session = requests.Session()
+    retry_strategy = Retry(
+        total=5,
+        backoff_factor=2,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+        raise_on_status=False
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
     try:
-        response = requests.get(url, headers=headers)
+        response = session.get(url, headers=headers, timeout=30)
         response.raise_for_status()
         with open(target, 'wb') as handle:
             handle.write(response.content)
         return target
     except Exception as E:
-        print(E)
+        print(f"Error downloading {url}: {E}")
         return None
 
 

--- a/run.py
+++ b/run.py
@@ -1,0 +1,123 @@
+""" This is a sample script for using RTK (Release the krakens)
+
+It takes a file with a list of manifests to download from IIIF (See manifests.txt) and passes it in a suit of commands:
+
+0. It downloads manifests and transform them into CSV files
+1. It downloads images from the manifests
+2. It applies YALTAi segmentation with line segmentation
+3. It fixes up the image PATH of XML files
+4. It processes the text as well through Kraken
+5. It removes the image files (from the one hunder object that were meant to be done in group)
+
+The batch file should be lower if you want to keep the space used low, specifically if you use DownloadIIIFManifest.
+
+"""
+from rtk.task import DownloadIIIFImageTask, KrakenAltoCleanUpCommand, ClearFileCommand, \
+    DownloadIIIFManifestTask, YALTAiCommand, KrakenRecognizerCommand, ExtractZoneAltoCommand
+from rtk import utils
+import os
+import zipfile
+import csv
+import json
+
+def read_manifest_identifiers(file_path):
+    with open(file_path, 'r') as file:
+        return json.load(file)
+
+# Function to create zip files
+def create_zip_files(identifier, output_directory, image_folder, xml_files, csv_file):
+    # Create zip for images
+    image_zip_path = os.path.join(output_directory, f"{identifier}_facsimile.zip")
+    with zipfile.ZipFile(image_zip_path, 'w') as zipf:
+        for root, dirs, files in os.walk(image_folder):
+            for file in files:
+                if file.endswith('.jpg'):
+                    zipf.write(os.path.join(root, file), os.path.relpath(os.path.join(root, file), image_folder))
+        # Add CSV file to the zip
+        zipf.write(csv_file, os.path.basename(csv_file))
+
+    # Create zip for XMLs
+    xml_zip_path = os.path.join(output_directory, f"{identifier}_altos_transcribed.zip")
+    with zipfile.ZipFile(xml_zip_path, 'w') as zipf:
+        for xml_file in xml_files:
+            zipf.write(xml_file, os.path.basename(xml_file))
+
+def get_image_folder_from_csv(csv_file):
+    with open(csv_file, 'r') as file:
+        reader = csv.reader(file)
+        for row in reader:
+            if row:
+                return row[1]  # Assuming the directory is the second column
+    return None
+
+manifest_identifiers, batches = utils.batchify_jsonfile('manifests.json', batch_size=2)
+from re import sub
+
+
+def kebab(s):
+    return sub(r"https?-", "", '-'.join(
+        sub(r"(\W+)"," ",
+        sub(r"[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+",
+        lambda mo: ' ' + mo.group(0).lower(), s)).split()
+    ))
+
+
+for batch in batches:
+    # Download Manifests
+    print("[Task] Download manifests")
+    dl = DownloadIIIFManifestTask(
+        batch,
+        output_directory="output",
+        naming_function=lambda x: kebab(x), multiprocess=10
+    )
+    dl.process()
+
+    # Download Files
+    print("[Task] Download JPG")
+    dl = DownloadIIIFImageTask(
+        dl.output_files,
+        max_height=2500,
+        multiprocess=4,
+        downstream_check=DownloadIIIFImageTask.check_downstream_task("xml", utils.check_content)
+    )
+    dl.process()
+
+    # Apply YALTAi
+    print("[Task] Segment")
+    yaltai = YALTAiCommand(
+        dl.output_files,
+        binary="yaltai",
+        device="cuda:0",
+        yolo_model="seg_model.pt",
+        raise_on_error=True,
+        allow_failure=False,
+        multiprocess=8,  # GPU Memory // 5gb
+        check_content=False
+    )
+    yaltai.process()
+
+    # Clean-up the relative filepath of Kraken Serialization
+    print("[Task] Clean-Up Serialization")
+    cleanup = KrakenAltoCleanUpCommand(yaltai.output_files)
+    cleanup.process()
+
+    # Apply Kraken
+    print("[Task] OCR")
+    kraken = KrakenRecognizerCommand(
+        yaltai.output_files,
+        binary="kraken",
+        device="cuda:0",
+        model="htr_model.mlmodel",
+        multiprocess=12,  # GPU Memory // 3gb
+        check_content=False
+    )
+    kraken.process()
+
+    for manifest_url in batch:
+        identifier = manifest_identifiers.get(manifest_url)
+        if identifier:
+            csv_file = os.path.join("output", kebab(manifest_url) + ".csv")
+            image_folder = get_image_folder_from_csv(csv_file)
+            if image_folder:
+                xml_files = [xml for xml in kraken.output_files if xml.startswith(image_folder)]
+                create_zip_files(identifier, "output", image_folder, xml_files, csv_file)

--- a/run.py
+++ b/run.py
@@ -54,12 +54,16 @@ manifest_identifiers, batches = utils.batchify_jsonfile('manifests.json', batch_
 from re import sub
 
 
-def kebab(s):
-    return sub(r"https?-", "", '-'.join(
+def kebab(s, max_length=255):
+    kebab_string = sub(r"https?-", "", '-'.join(
         sub(r"(\W+)"," ",
         sub(r"[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+",
         lambda mo: ' ' + mo.group(0).lower(), s)).split()
     ))
+    # trunc
+    if len(kebab_string) > max_length:
+        kebab_string = kebab_string[:max_length].rsplit('-', 1)[0]  # Truncate the last hyphen to avoid a break in the middle of the word
+    return kebab_string
 
 
 for batch in batches:

--- a/run.py
+++ b/run.py
@@ -19,6 +19,7 @@ import os
 import zipfile
 import csv
 import json
+import torch
 
 def read_manifest_identifiers(file_path):
     with open(file_path, 'r') as file:
@@ -95,10 +96,12 @@ for batch in batches:
         yolo_model="seg_model.pt",
         raise_on_error=True,
         allow_failure=False,
-        multiprocess=8,  # GPU Memory // 5gb
+        multiprocess=4,  # GPU Memory // 5gb
         check_content=False
     )
     yaltai.process()
+
+    torch.cuda.empty_cache()
 
     # Clean-up the relative filepath of Kraken Serialization
     print("[Task] Clean-Up Serialization")
@@ -112,10 +115,12 @@ for batch in batches:
         binary="kraken",
         device="cuda:0",
         model="htr_model.mlmodel",
-        multiprocess=12,  # GPU Memory // 3gb
+        multiprocess=8,  # GPU Memory // 3gb
         check_content=False
     )
     kraken.process()
+
+    torch.cuda.empty_cache()
 
     for manifest_url in batch:
         identifier = manifest_identifiers.get(manifest_url)

--- a/run.py
+++ b/run.py
@@ -54,7 +54,7 @@ manifest_identifiers, batches = utils.batchify_jsonfile('manifests.json', batch_
 from re import sub
 
 
-def kebab(s, max_length=255):
+def kebab(s, max_length=100):
     kebab_string = sub(r"https?-", "", '-'.join(
         sub(r"(\W+)"," ",
         sub(r"[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+",

--- a/run.py
+++ b/run.py
@@ -75,7 +75,8 @@ for batch in batches:
     dl = DownloadIIIFManifestTask(
         batch,
         output_directory="output",
-        naming_function=lambda x: kebab(x), multiprocess=10
+        naming_function=lambda x: kebab(x), multiprocess=10,
+        custom_headers={'User-Agent': 'curl/8.0'}
     )
     dl.process()
 
@@ -85,7 +86,8 @@ for batch in batches:
         dl.output_files,
         max_height=2500,
         multiprocess=4,
-        downstream_check=DownloadIIIFImageTask.check_downstream_task("xml", utils.check_content)
+        downstream_check=DownloadIIIFImageTask.check_downstream_task("xml", utils.check_content),
+        custom_headers={'User-Agent': 'curl/8.0'}
     )
     dl.process()
 

--- a/run_pdf.py
+++ b/run_pdf.py
@@ -76,7 +76,7 @@ for batch in batches:
         yolo_model="seg_model.pt",
         raise_on_error=True,
         allow_failure=False,
-        multiprocess=4,  # GPU Memory // 5gb
+        multiprocess=8,  # GPU Memory // 5gb
         check_content=False
     )
     yaltai.process()
@@ -95,7 +95,7 @@ for batch in batches:
         binary="kraken",
         device="cuda:0",
         model="nfd_best.mlmodel",
-        multiprocess=8,  # GPU Memory // 3gb
+        multiprocess=16,  # GPU Memory // 3gb
         check_content=False
     )
     kraken.process()

--- a/run_pdf.py
+++ b/run_pdf.py
@@ -1,0 +1,110 @@
+""" This is a sample script for using RTK (Release the krakens)
+
+It takes a file with a list of manifests to download from IIIF (See manifests.txt) and passes it in a suit of commands:
+
+0. It downloads manifests and transform them into CSV files
+1. It downloads images from the manifests
+2. It applies YALTAi segmentation with line segmentation
+3. It fixes up the image PATH of XML files
+4. It processes the text as well through Kraken
+5. It removes the image files (from the one hunder object that were meant to be done in group)
+
+The batch file should be lower if you want to keep the space used low, specifically if you use DownloadIIIFManifest.
+
+"""
+from rtk.task import KrakenAltoCleanUpCommand, ClearFileCommand, YALTAiCommand, KrakenRecognizerCommand, ExtractPDFTask
+from rtk import utils
+import os
+import zipfile
+import json
+import torch
+
+def read_manifest_identifiers(file_path):
+    with open(file_path, 'r') as file:
+        return json.load(file)
+
+# Function to create zip files
+def create_zip_files(identifier, output_directory, image_folder):
+    image_zip_path = os.path.join(output_directory, f"{identifier}_facsimile.zip")
+    with zipfile.ZipFile(image_zip_path, 'w', compression=zipfile.ZIP_DEFLATED) as zipf:
+        for root, dirs, files in os.walk(image_folder):
+            for file in files:
+                if file.endswith('.jpg'):
+                    zipf.write(os.path.join(root, file), os.path.relpath(os.path.join(root, file), image_folder))
+
+    # Create zip for XMLs
+    xml_zip_path = os.path.join(output_directory, f"{identifier}_altos_transcribed.zip")
+    with zipfile.ZipFile(xml_zip_path, 'w', compression=zipfile.ZIP_DEFLATED) as zipf:
+        for root, dirs, files in os.walk(image_folder):
+            for file in files:
+                if file.endswith('.xml'):
+                    zipf.write(os.path.join(root, file), os.path.relpath(os.path.join(root, file), image_folder))
+
+manifest_identifiers, batches = utils.batchify_jsonfile('pdfs.json', batch_size=2)
+
+from re import sub
+
+
+def kebab(s, max_length=100):
+    kebab_string = sub(r".pdf", "", '-'.join(
+        sub(r"(\W+)"," ",
+        sub(r"[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+",
+        lambda mo: ' ' + mo.group(0).lower(), s)).split()
+    ))
+    # trunc
+    if len(kebab_string) > max_length:
+        kebab_string = kebab_string[:max_length].rsplit('-', 1)[0]  # Truncate the last hyphen to avoid a break in the middle of the word
+    return kebab_string
+
+
+for batch in batches:
+    # Download Manifests
+    print("[Task] Extract PDFs")
+    dl = ExtractPDFTask(
+        batch,
+        output_directory="output",
+        naming_function=lambda x: kebab(x), multiprocess=10
+    )
+    dl.process()
+
+    # Apply YALTAi
+    print("[Task] Segment")
+    yaltai = YALTAiCommand(
+        dl.output_files,
+        binary="yaltai",
+        device="cuda:0",
+        yolo_model="seg_model.pt",
+        raise_on_error=True,
+        allow_failure=False,
+        multiprocess=4,  # GPU Memory // 5gb
+        check_content=False
+    )
+    yaltai.process()
+
+    torch.cuda.empty_cache()
+
+    # Clean-up the relative filepath of Kraken Serialization
+    print("[Task] Clean-Up Serialization")
+    cleanup = KrakenAltoCleanUpCommand(yaltai.output_files)
+    cleanup.process()
+
+    # Apply Kraken
+    print("[Task] OCR")
+    kraken = KrakenRecognizerCommand(
+        yaltai.output_files,
+        binary="kraken",
+        device="cuda:0",
+        model="nfd_best.mlmodel",
+        multiprocess=8,  # GPU Memory // 3gb
+        check_content=False
+    )
+    kraken.process()
+
+    torch.cuda.empty_cache()
+
+    for pdf in batch:
+        identifier = manifest_identifiers.get(pdf)
+        if identifier:
+            image_folder = os.path.join(kebab(pdf))
+            if image_folder:
+                create_zip_files(identifier, "output", image_folder)


### PR DESCRIPTION
Possible fix (#7) to allow the pipeline to parse alto files and consider them as an OCR job if all @CONTENT in the file are empty.