### PR TITLE
Fix to quickyaltaiinstall.sh if virtualenv is not installed

### DIFF
--- a/quickyaltaiinstall.sh
+++ b/quickyaltaiinstall.sh
@@ -1,5 +1,5 @@
-virtualenv -p python3.10 yaltaienv
+python3.10 -m venv yaltaienv
 yaltaienv/bin/pip install YALTAi --extra-index-url https://download.pytorch.org/whl/cpu
 
-virtualenv -p python3.10 krakenv
+python3.10 -m venv krakenv
 krakenv/bin/pip install kraken --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
I was getting the following error when executing quickyaltaiinstall.sh

```
./quickyaltaiinstall.sh: line 1: virtualenv: command not found
./quickyaltaiinstall.sh: line 2: yaltaienv/bin/pip: No such file or directory
./quickyaltaiinstall.sh: line 4: virtualenv: command not found
./quickyaltaiinstall.sh: line 5: krakenv/bin/pip: No such file or directory
```

`python3.10 -m venv` can be used as an alternative to `virtualenv -p python3.10`. 